### PR TITLE
[codex] Add changelog and release-note guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Notable changes to the public Vorlek status page.
+
+## 2026-05-10
+
+- Stabilized the status-page gutter and header layout.
+- Fixed the status header link and aligned it with Vorlek navigation.
+
+## Earlier
+
+- Replaced the legacy Upptime-generated codebase with a small Gatus deployment on Fly.io.
+- Added monitors for API, dashboard, docs, ci-live, MCP package, TypeScript SDK package, and Python SDK package.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Production URL: [status.vorlek.com](https://status.vorlek.com)
 
 Fly URL: [vorlek-status.fly.dev](https://vorlek-status.fly.dev)
 
+Release history lives in [`CHANGELOG.md`](./CHANGELOG.md). Update it alongside
+major monitor, deploy, and status-page UI changes.
+
 ## What Runs Here
 
 This repo has replaced the legacy Upptime-generated codebase with a small Gatus deployment:


### PR DESCRIPTION
Adds a baseline CHANGELOG.md and README release-note guidance for major status-page changes.\n\nValidation: git diff --check.